### PR TITLE
Support for attachments in documents

### DIFF
--- a/app-pouchdb-database-behavior.html
+++ b/app-pouchdb-database-behavior.html
@@ -53,12 +53,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         },
 
         /**
+         * Set to true if attachments should be returned in the document.
+         */
+        attachments: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Set to true if attachments should be returned in binary form,
+         * which is represented as a Blob in the browser. Does nothing if
+         * attachments is set to false.
+         */
+        binary: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * A reference to the PouchDB database instance that has been created.
          */
         db: {
           type: Object,
           computed: '__computeDb(dbName, adapter, revsLimit)',
-          notify: true,
+          notify: true
         },
 
         /**
@@ -84,6 +102,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type: Function,
           value: null
         }
+      },
+
+      get _dbReadOptions() {
+        return {
+          attachments: this.attachments,
+          binary: this.binary
+        };
       },
 
       /**
@@ -133,7 +158,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       _upsert: function(path, value, doc) {
         var lookup = doc._id != null ?
-            this.db.get(doc._id) :
+            this.db.get(doc._id, this._dbReadOptions) :
             Promise.reject({ status: 404 });
 
         this._log('Upsert', path, value, doc);

--- a/app-pouchdb-document.html
+++ b/app-pouchdb-document.html
@@ -143,7 +143,7 @@ PouchDB document:
 
       /** @override */
       getStoredValue: function(storagePath) {
-        return this.db.get(this.docId).then(function(doc) {
+        return this.db.get(this.docId, this._dbReadOptions).then(function(doc) {
           return this.get(storagePath, {
             data: doc
           });
@@ -171,7 +171,9 @@ PouchDB document:
         this._log('Doc / ID changed', doc, docId);
         if (db && doc != null && docId != null && doc._id != docId) {
           doc._id = docId;
-          this._initializeStoredValue();
+          this.async(function() {
+            this._initializeStoredValue();
+          }, 1);
         }
       },
 
@@ -188,12 +190,19 @@ PouchDB document:
           return null;
         }
 
-        return db.changes({
+        var changeOptions = {
           since: 'now',
           live: true,
           doc_ids: [docId],
-          include_docs: true,
-        }).on('change', function(change) {
+          include_docs: true
+        };
+        var readOptions = this._dbReadOptions;
+
+        for (var i in readOptions) {
+          changeOptions[i] = readOptions[i];
+        }
+
+        return db.changes(changeOptions).on('change', function(change) {
           var doc = change.doc;
           this.syncToMemory(function() {
             this.set('data', doc);

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "polymer": "polymer/polymer#^v1.2.0",
     "pouchdb": "^5.3.1",
-    "pouchdb-find": "^0.9.0",
+    "pouchdb-find": "^0.10.0",
     "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
     "app-storage": "polymerelements/app-storage#~0.9.0"
   },


### PR DESCRIPTION
This change forwards configuration from attributes on the element to `PouchDB` API calls.
