### PR TITLE
Fixes #22 - variable names incorrect in database initialization

### DIFF
--- a/app-pouchdb-database-behavior.html
+++ b/app-pouchdb-database-behavior.html
@@ -227,7 +227,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }.bind(this));
       },
 
-      __computeDb: function(name, revsLimit, adapter) {
+      __computeDb: function(name, adapter, revsLimit) {
         if (this.db) {
           this.db.removeAllListeners();
         }


### PR DESCRIPTION
Arguments in function `__computeDb` were switched which was causing an error when was trying to insert document into the data store.