### PR TITLE
Pin PouchDB to ~6.0.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "polymer/polymer#^v1.2.0",
-    "pouchdb": "^6.0.4",
+    "pouchdb": "~6.0.7",
     "pouchdb-find": "^0.10.0",
     "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
     "app-storage": "polymerelements/app-storage#~0.9.0"


### PR DESCRIPTION
Partially fixes #32 . Another fix is required so that we aren't pinned to an old version of PouchDB indefinitely.