### PR TITLE
depend on pouchdb 6.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "polymer/polymer#^v1.2.0",
-    "pouchdb": "~6.0.7",
+    "pouchdb": "^6.1.1",
     "pouchdb-find": "^0.10.0",
     "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
     "app-storage": "polymerelements/app-storage#~0.9.0"


### PR DESCRIPTION
dist folder was missing, and now it is not. [see](https://github.com/pouchdb/pouchdb/issues/6112)