### PR TITLE
fix adapter and revslimit options when creating a new db

### DIFF
--- a/app-pouchdb-database-behavior.html
+++ b/app-pouchdb-database-behavior.html
@@ -227,7 +227,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }.bind(this));
       },
 
-      __computeDb: function(name, revsLimit, adapter) {
+      __computeDb: function(name, adapter, revsLimit) {
         if (this.db) {
           this.db.removeAllListeners();
         }


### PR DESCRIPTION
When creating a db, it seems that the `adapter` and `revsLimit` options have been switched, leading to wrong values when using either.

https://github.com/PolymerElements/app-pouchdb/blob/c06d7f0175c8c148e876247d67e81707ad807f3b/app-pouchdb-database-behavior.html#L60


```
...
db: {
  type: Object,
    computed: '__computeDb(dbName, adapter, revsLimit)',
    notify: true
  }
}
...
```

https://github.com/PolymerElements/app-pouchdb/blob/c06d7f0175c8c148e876247d67e81707ad807f3b/app-pouchdb-database-behavior.html#L230

```
...
__computeDb: function(name, revsLimit, adapter) {
...
```